### PR TITLE
Allow reopen

### DIFF
--- a/lua/menu/init.lua
+++ b/lua/menu/init.lua
@@ -10,8 +10,12 @@ local mappings = require "menu.mappings"
 M.open = function(items, opts)
   opts = opts or {}
 
-  if #state.bufids > 0 and not opts.nested then
-    return
+  -- Close before opening another instance.
+  for _, win in ipairs(vim.api.nvim_list_wins()) do
+    local buf = vim.api.nvim_win_get_buf(win)
+    if vim.bo[buf].ft == "NvMenu" then
+      vim.api.nvim_win_close(win, true)
+    end
   end
 
   local cur_buf = api.nvim_get_current_buf()

--- a/lua/menu/init.lua
+++ b/lua/menu/init.lua
@@ -10,14 +10,6 @@ local mappings = require "menu.mappings"
 M.open = function(items, opts)
   opts = opts or {}
 
-  -- Close before opening another instance.
-  for _, win in ipairs(vim.api.nvim_list_wins()) do
-    local buf = vim.api.nvim_win_get_buf(win)
-    if vim.bo[buf].ft == "NvMenu" then
-      vim.api.nvim_win_close(win, true)
-    end
-  end
-
   local cur_buf = api.nvim_get_current_buf()
 
   if vim.bo[cur_buf].ft ~= "NvMenu" then


### PR DESCRIPTION
**DEMO**: https://www.youtube.com/watch?v=foVP_ElIbtM

## Explanation
* This PR reverts 349930b98590f10784e66340963aad2b4bf862c7
* It's important we allow opening multiple instances so users can  control it on their side.

This code respect the behavior the native neovim right click menu has.

```lua
-- function to create the right click menu.
-- @param is_mouse boolean
local function right_click_menu(is_mouse)
  -- If the window already exists, close it before opening another one.
  for _, win in ipairs(vim.api.nvim_list_wins()) do
    local buf = vim.api.nvim_win_get_buf(win)
    if vim.bo[buf].filetype == "NvMenu" then
      vim.api.nvim_win_close(win, true)
    end
  end


  if is_mouse == nil then is_mouse = true end
  local options = vim.bo.ft == "NvimTree" and "nvimtree" or menu_opts
  require("menu").open(options, { mouse = is_mouse, border = true })
end

maps.n["<C-t>"] =
{ function() right_click_menu(false) end, desc = "Open right click menu" }
maps.v["<C-t>"] =
{ function() right_click_menu(false) end, desc = "Open right click menu" }

maps.n["<RightMouse>"] = { right_click_menu, desc = "Open right click menu" }
maps.v["<RightMouse>"] = { right_click_menu, desc = "Open right click menu" }
```

