### PR TITLE
fix: set win back to current win when closing menus

### DIFF
--- a/lua/menu/init.lua
+++ b/lua/menu/init.lua
@@ -91,6 +91,7 @@ M.open = function(items, opts)
     state.config = nil
 
     if api.nvim_win_is_valid(state.old_data.win) then
+      api.nvim_set_current_win(state.old_data.win)
       api.nvim_win_set_cursor(state.old_data.win, state.old_data.cursor)
     end
 


### PR DESCRIPTION
Fix for https://github.com/NvChad/menu/issues/8

This sets the current window back to the window in state.